### PR TITLE
Add initial "DisplayKnob" code for handling the Loupedeck CT's big knob.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Release binary
 loupetest
 displayknob
+draw
 
 # Emacs temp files
 \#*\#
-\#*
+.\#*
 *~

--- a/displayknob.go
+++ b/displayknob.go
@@ -1,0 +1,426 @@
+package loupedeck
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"log/slog"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/jphsd/graphics2d"
+)
+
+var (
+	colorActive     = color.RGBA{192, 192, 192, 255}
+	colorInActive   = color.RGBA{64, 64, 64, 255}
+	colorBackground = color.RGBA{0, 0, 0, 255}
+)
+
+// DisplayKnob is an abstraction over the Loupedeck CT's large knob
+// with a display.  This is basically the IntKnob code, but with the
+// Knob parameter removed, since there's only one DisplayKnob today,
+// and it uses different messages, so shoehorning it into the IntKnob
+// code would be messy.
+type DisplayKnob struct {
+	watchedint *WatchedInt
+	min        int
+	max        int
+}
+
+// Get returns the current value of the DisplayKnob.
+func (k *DisplayKnob) Get() int {
+	return k.watchedint.Get()
+}
+
+// Set sets the current value of the DisplayKnob, triggering any
+// callbacks set on the WatchedInt that underlies the DisplayKnob.
+func (k *DisplayKnob) Set(v int) {
+	if v < k.min {
+		v = k.min
+	}
+	if v > k.max {
+		v = k.max
+	}
+	k.watchedint.Set(v)
+}
+
+// Inc incremements (or decrements) the current value of the
+// IntKnob by a specified amount.  This triggers a callback on the
+// WatchedInt that underlies the DisplayKnob.
+func (k *DisplayKnob) Inc(v int) {
+	x := k.watchedint.Get()
+	x += v
+	if x < k.min {
+		x = k.min
+	}
+	if x > k.max {
+		x = k.max
+	}
+	k.watchedint.Set(x)
+}
+
+// DisplayKnob implements a generic dial knob for the big knob in the
+// Loupedeck CT (the one with a display in the middle, hence the name
+// "DisplayKnob"). It binds the dial function of the knob to
+// increase/decrease the DisplayKnob's value.  This is very similar to
+// the IntKnob, except it (a) doesn't support click-to-reset (the big
+// knob doesn't click) and (b) it uses different messages under the
+// hood when talking to the Loupedeck.
+func (l *Loupedeck) DisplayKnob(min int, max int, watchedint *WatchedInt) *DisplayKnob {
+	k := &DisplayKnob{
+		watchedint: watchedint,
+		min:        min,
+		max:        max,
+	}
+	l.BindKnob(CTKnob, func(_ Knob, v int) {
+		k.Inc(v)
+	})
+	return k
+}
+
+// DragDisplayKnobFunc is a callback for handling drag events from the
+// touchscreen in the middle of the Loupedeck CT's big knob.
+type DragDisplayKnobFunc func(event DragEvent, x, y int)
+
+// Quick hack to decide if a touch is a click or a drag.  In an ideal
+// world, we'd also support double-click, but that either requires
+// knowing the future or delaying click messages until after a
+// specified time has passed without a second click, and there's no
+// room in the code for either today.
+func isClick(duration time.Duration, x, y int) bool {
+	if duration > 500*time.Millisecond {
+		return false
+	}
+
+	if x > 20 || x < -20 {
+		return false
+	}
+
+	if y > 20 || y < -20 {
+		return false
+	}
+
+	return true
+}
+
+// RegisterDragDisplayKnobWatcher registers a callback function for managing
+// click and drag events for the touchscreen in the middle of the
+// Loupedeck CT's big dial.  Only one watcher can be registered at a
+// time; if it is called a second time then the previous function will
+// be silently replaced.
+//
+// The function provided will be called with a DragEvent and a set of
+// X and Y values.  If DragEvent is loupedeck.DragClick, then a click
+// occured, and the X and Y parameters are the location where the
+// click started.  If the DragEvent is loupedeck.DragDone, then the X
+// and Y values are the *delta* that was dragged; the upper left is
+// negative and the lower right is positive.  This is intended to be
+// used to decide between a left and a right swipe, and that's about
+// it for now.
+func (l *Loupedeck) RegisterDragDisplayKnobWatcher(f DragDisplayKnobFunc) {
+	l.dragDKBinding = f
+	l.BindTouchCT(func(b ButtonStatus, x, y uint16) {
+		if !l.dragDKStarted {
+			// Not dragging yet
+			if b == ButtonDown {
+				// Starting dragging
+				l.dragDKStarted = true
+				l.dragDKStartX = x
+				l.dragDKStartY = y
+				l.dragDKStartTime = time.Now()
+			} else if b == ButtonUp {
+				// Where did *that* come from?
+				slog.Warn("Received CT ButtonUp event while not dragging")
+			} else {
+				slog.Warn("Received unknown CT button event while not dragging", "event", b)
+			}
+		} else {
+			// Already started dragging
+			if b == ButtonDown {
+				// Already dragging, can probably just ignore
+			} else if b == ButtonUp {
+				// Drag completed, let's see what happened...
+				duration := time.Since(l.dragDKStartTime)
+				dx := int(x) - int(l.dragDKStartX)
+				dy := int(y) - int(l.dragDKStartY)
+				fmt.Printf("Drag event: dX: %d dY: %d  elapsed: %v\n", dx, dy, duration)
+				l.dragDKStarted = false
+
+				if isClick(duration, dx, dy) {
+					l.dragDKBinding(DragClick, int(x), int(y)) // use x/y, not dx/dy
+				} else {
+					l.dragDKBinding(DragDone, dx, dy) // Show the distance moved, not the location.
+				}
+
+			} else {
+				slog.Warn("Received unknown CT button event while dragging", "event", b)
+			}
+		}
+	})
+}
+
+// So, what I *really* want here is a set of widgets that I can
+// display on the knob display, each of which control a different
+// thing, possibly with slightly different UIs.  For instance, I could
+// have a set of 4 widget "tabs":
+//
+// - Camera gain control (analog, 0%-200%)
+// - Camera white balance (analog, 3000K-9000K)
+// - Background video selector (discrete selections, spin to select)
+// - Motorized curtain control (up/down, spin to raise/lower)
+//
+// When the app starts, it shows the camera gain widget.  Swiping
+// right takes you to the white balance widget, then the background
+// widget, then the curtain widget.  Presumably we'd show a set of 4
+// grey/white blips at the bottom, and swiping would move the blip (as
+// well as redrawing the display, possibly with a transition effect).
+//
+// Then, for any specific widget, the dial behavior (and possibly
+// up/down swipes) would control something widget-specific.  Examples:
+//
+// - Analog base widget. Spinning the dial changes numeric value
+//   between `min` and `max`.  The widget draws a partial ring around
+//   the outside of the widget to show the current setting, and the
+//   widget can draw numeric values as needed.
+//
+// - A discrete number widget.  Think camera iris control.  Works just
+//   like the analog widget, but only specific values are allowed.
+//   For iris, think "f/2.0", "f/2.2", "f/2.5", "f/2.8", etc.
+//
+// - A boolean widget.  Similar to the discrete widget, but only
+//   true/false (allow names to be specified--on/off, true/false, etc).
+//
+// - Fully custom widgets.  Imagine a background selector, which let
+//   you choose between various background images or videos.  *Might*
+//   be overlap here with the discrete widget.  Requirement: be able
+//   to add/remove options on the fly.  Applies to the iris widget as
+//   well; changing lenses changes the allowed set of iris settings.
+//
+// So, the possibly-odd thing here is the dial binding, as right now,
+// it's only bound once globally.  When changing widgets, do we unbind
+// the previous one and just set up it from scratch again?  I think
+// that'd actually work fine, by accident.
+//
+// To make room for widget-holder graphics, let's limit widgets to
+// 240x220, saving the bottom 20px for the holder.
+
+// DKWidget is an interface that describes a generic widget for use
+// with the Loupedeck CT's knob.
+type DKWidget interface {
+	Activate(*Loupedeck)
+	Deactivate(*Loupedeck)
+
+	// Do we need Draw() or similar?  Shouldn't need (or want) Get/Set
+}
+
+// DKAnalogWidget is a widget for use with the Loupedeck CT's larget
+// display knob.  It controls a single analog variable; turning the
+// knob one direction decreases the value, turning it the other way
+// increases the value.
+type DKAnalogWidget struct {
+	Min, Max                 int
+	MinDegrees, TotalDegrees float64 // 0 is straight up
+	Value                    *WatchedInt
+	Name                     string
+	active                   bool
+}
+
+// NewDKAnalogWidget creates a new DKAnalogWidget
+func NewDKAnalogWidget(min, max int, value *WatchedInt, name string) *DKAnalogWidget {
+	w := &DKAnalogWidget{
+		Min:          min,
+		Max:          max,
+		Value:        value,
+		Name:         name,
+		MinDegrees:   135,
+		TotalDegrees: 270,
+	}
+
+	return w
+}
+
+// Activate is called when the widget gains focus.  It needs to re-set
+// the CT knob so that it updates this widget's controls.
+func (w *DKAnalogWidget) Activate(l *Loupedeck) {
+	w.active = true
+	_ = l.DisplayKnob(w.Min, w.Max, w.Value)
+	w.Draw(l)
+}
+
+// Deactivate is called when the widget loses focus.
+func (w *DKAnalogWidget) Deactivate(l *Loupedeck) {
+	w.active = false
+}
+
+func d2r(d float64) float64 {
+	return d * math.Pi / 180
+}
+
+// Draw draws the widget on the display if the widget is currently active.
+//
+// Note that this is kind of expensive as it sends a lot of bits to
+// the Loupedeck, and it's possible to lag several seconds behind when
+// the user spins the dial quickly.  We'll probably want to break this
+// out into its own thread, and only allow ~1 draw at a time to be
+// queued.  Then, when the user spins the dial, we do *one* draw, then
+// fetch new events, which try to queue up a zillion new draw events,
+// but we only allow one to be queued at a time, so we end up doing 1
+// draw per event block.  I think.
+//
+// Since none of the code is really thread-safe yet, this will take a
+// bit more work.  At a minimum, we'll need to add locks around USB
+// communication.
+//
+// The alternative would be to do some sort of "future draw" thing,
+// where draws are scheduled for (say) 100ms in the future, and then
+// we drop duplicates.  Then we inject the "draw event" back into the
+// main loop, so we don't need to worry about locking.  Might be
+// easier, and likely it'd have better performance.
+func (w *DKAnalogWidget) Draw(l *Loupedeck) {
+	// Only draw if we have the focus
+	if !w.active {
+		return
+	}
+
+	display := l.GetDisplay("dial")
+
+	fmt.Printf("Should draw widget %q here.\n", w.Name)
+
+	// TODO: actually draw something.
+
+	im := image.NewRGBA(image.Rect(0, 0, 240, 210))
+	bg := colorBackground
+	draw.Draw(im, im.Bounds(), &image.Uniform{bg}, image.Point{}, draw.Src)
+
+	startRadian := d2r(w.MinDegrees + 180)
+	startX := math.Cos(startRadian)*110 + 120
+	startY := math.Sin(startRadian)*110 + 120
+
+	radians := d2r(w.TotalDegrees)
+	stopRadian := radians
+
+	fmt.Printf("X: %f, Y: %f, startRadian: %f, radians: %f, stopRadian: %f\n", startX, startY, startRadian, radians, stopRadian)
+
+	pen := graphics2d.NewPen(colorInActive, 1)
+	// I'm officially mystified by the graphics2d coordinate
+	// system, but this seems to draw correct arcs.  I started
+	// with angle=0 being to the east and (x, y) coordinates, but
+	// that didn't come even close.  This seems draws correctly;
+	// I'll look at it again another day.
+	graphics2d.DrawArc(im, []float64{startY, startX}, []float64{120, 120}, stopRadian, pen)
+
+	stopRadian = radians * (float64(w.Value.Get()) / float64(w.Max))
+	pen = graphics2d.NewPen(colorActive, 4)
+	graphics2d.DrawArc(im, []float64{startY, startX}, []float64{120, 120}, stopRadian, pen)
+
+	fd := l.FontDrawer()
+	fd.Dst = im
+
+	drawCenteredStringAt(fd, w.Name, 120, 80)
+	drawCenteredStringAt(fd, strconv.Itoa(w.Value.Get()), 120, 160)
+
+	display.Draw(im, 0, 0)
+}
+
+// WidgetHolder is a container that can hold multiple DKWidgets and
+// allows the user to select between them by swiping right/left on the
+// CT's display.
+func (l *Loupedeck) WidgetHolder(widgets []DKWidget) {
+	active := 0
+	count := len(widgets)
+	widgets[0].Activate(l)
+
+	l.RegisterDragDisplayKnobWatcher(func(b DragEvent, x, y int) {
+		if b == DragClick {
+			fmt.Printf("Click at %d, %d\n", x, y)
+		} else if b == DragDone {
+			fmt.Printf("Drag, direction is %d, %d\n", x, y)
+
+			if x < -20 {
+				widgets[active].Deactivate(l)
+				active++
+				if active >= count {
+					active = 0
+				}
+				widgets[active].Activate(l)
+				l.drawWidgetHolderNavBar(active, count)
+			} else if x > 20 {
+				widgets[active].Deactivate(l)
+				active--
+				if active < 0 {
+					active = count - 1
+				}
+				widgets[active].Activate(l)
+				l.drawWidgetHolderNavBar(active, count)
+			}
+		}
+	})
+	l.drawWidgetHolderNavBar(0, count)
+}
+
+// drawWidgetHolderNavBar draws in the bottom 20x240 of the knob to
+// show which swipable tab the user is currently on and give context.
+// Since the knob is circular, most of those pixels aren't actually
+// visible, but it's probably still enough room for a few dots.  We
+// might need to change that to 30x or 40x if we need more room.
+func (l *Loupedeck) drawWidgetHolderNavBar(position int, tabCount int) {
+	// Let's just draw "blips" per tab at the bottom of the screen
+	// for each tab, and highlight the current tab's blip in a
+	// brighter color.  That's fine for up to ~10 tabs, after that
+	// the blips start to get pretty small and we'll probably want
+	// to scroll or something.  OTOH, that's a lot of tabs, so
+	// maybe we don't care.
+	//
+	//
+	// A bit of math; we have a circular display with r=120px.  If
+	// we lop off S pixels at the bottom, then the circular area
+	// is 2*sqrt(2*s*r-s^s) pixels wide.  Calculating the angle is
+	// left as an exercise for the reader, but when S=30 we're
+	// looking at about 70 degrees total.
+
+	if tabCount > 10 {
+		panic("We can't draw more than 10 tabs right now.  So either create fewer tabs or fix the logic in displayknob.go")
+	}
+
+	// We have about 70 degrees available, but we don't want to
+	// spread out *too* much.  Plus, at the edges will end up
+	// cropping the dots on the top edge of the 30-pixel boundry.
+	// So let's use 60 degrees total, and then cap the spread to
+	// 20 degrees per tab.
+	degreesPerTab := 60 / float64(tabCount)
+	if degreesPerTab > 20 {
+		degreesPerTab = 20
+	}
+	anglePerTab := d2r(degreesPerTab)
+	totalAngle := anglePerTab * float64(tabCount-1)
+	leftMostAngle := -(totalAngle / 2)
+
+	display := l.GetDisplay("dial")
+
+	im := image.NewRGBA(image.Rect(0, 0, 240, 30))
+	bg := colorBackground
+	draw.Draw(im, im.Bounds(), &image.Uniform{bg}, image.Point{}, draw.Src)
+	penActive := graphics2d.NewPen(colorActive, 10)
+	penInActive := graphics2d.NewPen(colorInActive, 8)
+	var pen *graphics2d.Pen
+
+	for i := 0; i < tabCount; i++ {
+		angle := leftMostAngle + anglePerTab*float64(i)
+		// I'm making 0 degrees straight down here, so sin/cos
+		// go to the wrong vars.  Sue me.
+		x := math.Sin(angle)*110 + 120
+		y := math.Cos(angle)*110 - 90 // We're only drawing into the bottom 30px of the image, so this is +120-210 = -90.
+
+		if i == position {
+			pen = penActive
+		} else {
+			pen = penInActive
+		}
+
+		graphics2d.DrawPoint(im, []float64{x, y}, pen)
+	}
+	display.Draw(im, 0, 210)
+}

--- a/examples/displayknob/displayknob.go
+++ b/examples/displayknob/displayknob.go
@@ -1,0 +1,59 @@
+package main
+
+// Demonstration code for using github.com/scottlaird/loupedeck in Go.
+//
+// This creates several buttons and does some back-end logic to use
+// the Loupedeck Live as a sort of minimal smart DMX controller, for
+// controlling my desktop video conferencing lights.  This is only a
+// partial implementation; it's intended as an example rather than a
+// full-blown DMX controller.  Specifically, this doesn't actually
+// talk to any DMX hardware.  The actual controller will live in its
+// own Github repo, link TBD.
+//
+
+import (
+	"fmt"
+
+	"github.com/scottlaird/loupedeck"
+)
+
+func main() {
+	l, err := loupedeck.ConnectAuto()
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+
+	go l.Listen()
+	l.SetDisplays()
+
+	// Create widgets
+	x1 := loupedeck.NewWatchedInt(50)
+	w1 := loupedeck.NewDKAnalogWidget(0, 100, x1, "AnalogTest")
+
+	x1.AddWatcher(func(i int) {
+		fmt.Printf("Knob (1) set to %d\n", i)
+		w1.Draw(l)
+	})
+
+	x2 := loupedeck.NewWatchedInt(10)
+	w2 := loupedeck.NewDKAnalogWidget(0, 30, x2, "Test 2")
+
+	x2.AddWatcher(func(i int) {
+		fmt.Printf("Knob (2) set to %d\n", i)
+		w2.Draw(l)
+	})
+
+	x3 := loupedeck.NewWatchedInt(70)
+	w3 := loupedeck.NewDKAnalogWidget(0, 100, x3, "Test 3")
+
+	x3.AddWatcher(func(i int) {
+		fmt.Printf("Knob (3) set to %d\n", i)
+		w3.Draw(l)
+	})
+
+	l.WidgetHolder([]loupedeck.DKWidget{w1, w2, w3})
+
+	select {} // Wait forever
+
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/gorilla/websocket v1.5.0
+	github.com/jphsd/graphics2d v0.0.0-20231205042405-a59d2a584501
 	go.bug.st/serial v1.6.0
 	golang.org/x/image v0.14.0
 	maze.io/x/pixel v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/jphsd/graphics2d v0.0.0-20231205042405-a59d2a584501 h1:lLE0o3mq6xTxN2puEdunjuwFO/6eU4ikl+OEXzQM+Ag=
+github.com/jphsd/graphics2d v0.0.0-20231205042405-a59d2a584501/go.mod h1:/c+Usas8JaaECLafs/Ce0wTao02PoJWoCdoXwFNlRuQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/inputs.go
+++ b/inputs.go
@@ -135,6 +135,21 @@ const (
 //   - The Y location touched (relative to the whole display)
 type TouchFunc func(TouchButton, ButtonStatus, uint16, uint16)
 
+// TouchDKFunc is a function signature used for callbacks on TouchCTButton
+// events, similar to TouchFunc.  The parameters are:
+//
+//   - The ButtonStatus (down/up)
+//   - The X location touched (relative to the whole display)
+//   - The Y location touched (relative to the whole display)
+type TouchDKFunc func(ButtonStatus, uint16, uint16)
+
+type DragEvent uint16
+
+const (
+	DragClick DragEvent = 1
+	DragDone  DragEvent = 2
+)
+
 // touchCoordToButton translates an x,y coordinate on the
 // touchscreen to a TouchButton.
 func touchCoordToButton(x, y uint16) TouchButton {
@@ -185,4 +200,9 @@ func (l *Loupedeck) BindTouch(b TouchButton, f TouchFunc) {
 // provided TouchFunc is called.
 func (l *Loupedeck) BindTouchUp(b TouchButton, f TouchFunc) {
 	l.touchUpBindings[b] = f
+}
+
+// BindTouchCT sets a callback for actions when the Loupedeck CT's touch button is touched.
+func (l *Loupedeck) BindTouchCT(f TouchDKFunc) {
+	l.touchDKBindings = f
 }

--- a/listen.go
+++ b/listen.go
@@ -2,8 +2,9 @@ package loupedeck
 
 import (
 	"encoding/binary"
-	"github.com/gorilla/websocket"
 	"log/slog"
+
+	"github.com/gorilla/websocket"
 )
 
 // Listen waits for events from the Loupedeck and calls
@@ -75,7 +76,8 @@ func (l *Loupedeck) Listen() {
 				} else {
 					slog.Debug("Received touch message", "x", x, "y", y, "id", id, "b", b, "message", message)
 				}
-			case TouchEndCT, TouchEnd:
+
+			case TouchEnd:
 				x := binary.BigEndian.Uint16(message[4:])
 				y := binary.BigEndian.Uint16(message[6:])
 				id := message[8] // Not sure what this is for
@@ -85,6 +87,24 @@ func (l *Loupedeck) Listen() {
 					l.touchUpBindings[b](b, ButtonUp, x, y)
 				} else {
 					slog.Debug("Received touch end message", "x", x, "y", y, "id", id, "b", b, "message", message)
+				}
+			case TouchCT:
+				x := binary.BigEndian.Uint16(message[4:])
+				y := binary.BigEndian.Uint16(message[6:])
+				id := message[8] // Not sure what this is for
+				slog.Debug("Received CT touch message", "x", x, "y", y, "id", id, "message", message)
+
+				if l.touchDKBindings != nil {
+					l.touchDKBindings(ButtonDown, x, y)
+				}
+			case TouchEndCT:
+				x := binary.BigEndian.Uint16(message[4:])
+				y := binary.BigEndian.Uint16(message[6:])
+				id := message[8] // Not sure what this is for
+				slog.Debug("Received CT touch message", "x", x, "y", y, "id", id, "message", message)
+
+				if l.touchDKBindings != nil {
+					l.touchDKBindings(ButtonUp, x, y)
 				}
 			default:
 				slog.Info("Received unknown message", "message", m.String())

--- a/loupedeck.go
+++ b/loupedeck.go
@@ -28,16 +28,19 @@
 package loupedeck
 
 import (
+	"image"
+	"image/color"
+	"image/draw"
+
 	"github.com/gorilla/websocket"
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/gofont/goregular"
 	"golang.org/x/image/font/opentype"
 	"golang.org/x/image/math/fixed"
-	"image"
-	"image/color"
-	"image/draw"
+
 	//	"log/slog"
 	"sync"
+	"time"
 )
 
 type transactionCallback func(m *Message)
@@ -59,10 +62,16 @@ type Loupedeck struct {
 	knobBindings         map[Knob]KnobFunc
 	touchBindings        map[TouchButton]TouchFunc
 	touchUpBindings      map[TouchButton]TouchFunc
+	touchDKBindings      TouchDKFunc
+	dragDKBinding        DragDisplayKnobFunc
 	transactionID        uint8
 	transactionMutex     sync.Mutex
 	transactionCallbacks map[byte]transactionCallback
 	displays             map[string]*Display
+	dragDKStarted        bool
+	dragDKStartX         uint16
+	dragDKStartY         uint16
+	dragDKStartTime      time.Time
 }
 
 // Close closes the connection to the Loupedeck.

--- a/touchdials.go
+++ b/touchdials.go
@@ -17,13 +17,14 @@
 package loupedeck
 
 import (
-	"golang.org/x/image/font"
-	"golang.org/x/image/math/fixed"
 	"image"
 	"image/color"
 	"image/draw"
 	"log/slog"
 	"strconv"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/math/fixed"
 )
 
 // TouchDial implements a "smart" bank of dials for the Loupedeck
@@ -110,6 +111,18 @@ func drawRightJustifiedStringAt(fd font.Drawer, s string, x, y int) {
 	slog.Info("Right justifying", "x", x, "y", y, "x26", x26, "y26", y26, "width", width)
 
 	fd.Dot = fixed.Point26_6{X: x26 - width, Y: y26}
+	fd.DrawString(s)
+}
+
+func drawCenteredStringAt(fd font.Drawer, s string, x, y int) {
+	bounds, _ := fd.BoundString(s)
+	width := bounds.Max.X - bounds.Min.X
+	x26 := fixed.I(x)
+	y26 := fixed.I(y)
+
+	slog.Info("Right justifying", "x", x, "y", y, "x26", x26, "y26", y26, "width", width)
+
+	fd.Dot = fixed.Point26_6{X: x26 - width/2, Y: y26}
 	fd.DrawString(s)
 }
 


### PR DESCRIPTION
Add the beginning of support for the big knob with the display in it on the Loupedeck CT.  

This includes low-level code for using the knob like one of the "regular" knobs, but also includes the beginnings of support for widgets on the display knob, with paging between the widgets.

At the moment, only a single widget type is included -- an analog dial that can be dialed up or down.  There is also a `WidgetHolder` that will display multiple widgets and allow left/right swipes to switch between them.  The naming here isn't final, and I'll probably break these out into a least a couple different files, but it's a good start.