### PR TITLE
ci: Stop running the release workflow for pushes to non-Main branches.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
We want to run it in `pull_request` mode for all pull requests, but only run it in `push` mode when pushing into `Main`.